### PR TITLE
Added is_map function to check is array map or plain array

### DIFF
--- a/msgpack_pack.c
+++ b/msgpack_pack.c
@@ -315,7 +315,7 @@ inline static void msgpack_serialize_array(
         msgpack_pack_nil(buf);
         msgpack_pack_long(buf, MSGPACK_SERIALIZE_TYPE_REFERENCE);
     }
-    else if (!msgpack_check_ht_is_map(val) && ht->nNumOfElements == ht->nNextFreeElement)
+    else if (!msgpack_check_ht_is_map(val))
     {
         hash = 0;
         msgpack_pack_array(buf, n);


### PR DESCRIPTION
This is copy of msgpack/msgpack#111 because of msgpack-php split.
Fixes msgpack/msgpack#87 (bug with incorrect packing of mixed arrays).

Patch is pretty straightforward.
