### PR TITLE
Fix crash with memcached

### DIFF
--- a/msgpack.c
+++ b/msgpack.c
@@ -255,6 +255,7 @@ PHP_MSGPACK_API void php_msgpack_unserialize(
 
     msgpack_unserialize_var_init(&var_hash);
 
+    RETVAL_NULL();
     mp.user.retval = (zval *)return_value;
     mp.user.var_hash = (msgpack_unserialize_data_t *)&var_hash;
 


### PR DESCRIPTION
Fix crash with memcached which calls msgpack_unserialize with a randomly initialized zval.
There is a corresponding PR for memcached https://github.com/php-memcached-dev/php-memcached/pull/157
But I think defense against such oversights should be in msgpack, too.