### PR TITLE
Update msgpack.c。貌似缺少一个头文件引入的判断

### DIFF
--- a/msgpack.c
+++ b/msgpack.c
@@ -8,7 +8,10 @@
 #include "ext/standard/info.h" /* for php_info */
 #include "ext/standard/php_incomplete_class.h" /* for incomplete_class */
 #include "ext/standard/php_var.h" /* for PHP_VAR_SERIALIZE */
+
+#if HAVE_PHP_SESSION
 #include "ext/session/php_session.h" /* for php_session_register_serializer */
+#endif
 
 #include "php_msgpack.h"
 #include "msgpack_pack.h"


### PR DESCRIPTION
我们买了SAE的MAE，发现他们的PHP定制过，修改了PHP的Session模块。导致MsgPack编译会报错：
msgpack-0.5.5/msgpack.c:11:79: error: ext/session/php_session.h: No such file or directory

我们查看了msgpack.c的源码，发现所有用到session的地方鸟哥都加了#if HAVE_PHP_SESSION，唯有include头文件的时候没有加。
所以我们加上了这个判断。不知理解是否正确？