### PR TITLE
Fix VC14 build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,7 +1,7 @@
 // $Id$
 // vim:ft=javascript
 
-ARG_ENABLE("msgpack", "for msgpack support", "yes");
+ARG_ENABLE("msgpack", "for msgpack support", "no");
 
 if (PHP_MSGPACK != "no") {
    EXTENSION("msgpack", "msgpack.c", PHP_MSGPACK_SHARED, "");

--- a/msgpack_unpack.c
+++ b/msgpack_unpack.c
@@ -49,7 +49,7 @@ typedef struct {
     zval_ptr_dtor(_val);                                         \
     MSGPACK_UNSERIALIZE_FINISH_ITEM(_unpack, _key, _val);
 
-#define MSGPACK_IS_STACK_VALUE(_v)   (Z_TYPE_P((_v)) < IS_ARRAY)
+#define MSGPACK_IS_STACK_VALUE(_v)   (Z_TYPE_P((zval *)(_v)) < IS_ARRAY)
 
 static zval *msgpack_var_push(msgpack_unserialize_data_t *var_hashx) /* {{{ */ {
     var_entries *var_hash, *prev = NULL;


### PR DESCRIPTION
@laruence I got an error C2100 - Illegal Indirection when I tried to compile this with VC14 and fixed it. I then ran the tests and got the following result (x86 NTS and TS):

	=====================================================================
	Number of tests :  118               118
	Tests skipped   :    0 (  0.0%) --------
	Tests warned    :    0 (  0.0%) (  0.0%)
	Tests failed    :    1 (  0.8%) (  0.8%)
	Expected fail   :    1 (  0.8%) (  0.8%)
	Tests passed    :  116 ( 98.3%) ( 98.3%)
	---------------------------------------------------------------------
	Time taken      :   25 seconds
	=====================================================================
	
	=====================================================================
	EXPECTED FAILED TEST SUMMARY
	---------------------------------------------------------------------
	Bug #2 (Deserializing a large array of nested objects gives "zend_mm_heap corrupted")
	[/php-sdk/php70dev/ext/msgpack/tests/bug002.phpt]  XFAIL REASON: Bug is not fixed yet
	=====================================================================
	
	=====================================================================
	FAILED TEST SUMMARY
	---------------------------------------------------------------------
	Check for double NaN, Inf, -Inf, 0, and -0 [/php-sdk/php70dev/ext/msgpack/tests/041.phpt]
	=====================================================================

Good enough for the moment, I think. BTW: test 41 failed because double NaN returned cbfff8000000000000 and the expected result was cb7ff8000000000000. I do not know if this is a Windows quirk. Maybe @weltling knows.