### PR TITLE
Compile as shared on snapshot build

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,7 +1,7 @@
 // $Id$
 // vim:ft=javascript
 
-ARG_ENABLE("msgpack", "for msgpack support", "yes");
+ARG_ENABLE("msgpack", "for msgpack support", "no");
 
 if (PHP_MSGPACK != "no") {
    EXTENSION("msgpack", "msgpack.c", PHP_MSGPACK_SHARED, "");


### PR DESCRIPTION
@laruence A snapshot build on Windows tries to compile an extension as static if the default is 'yes'. Please change this in 'no'.