### PR TITLE
Check hash protection flag to avoid memory corruption

### DIFF
--- a/msgpack_pack.c
+++ b/msgpack_pack.c
@@ -283,11 +283,11 @@ static inline void msgpack_serialize_array(smart_str *buf, zval *val, HashTable 
 				if ((Z_TYPE_P(value_noref) == IS_ARRAY && ZEND_HASH_GET_APPLY_COUNT(Z_ARRVAL_P(value_noref)) > 1)) {
 					msgpack_pack_nil(buf);
 				} else {
-					if (Z_TYPE_P(value_noref) == IS_ARRAY) {
+					if (Z_TYPE_P(value_noref) == IS_ARRAY && ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(value_noref))) {
 						ZEND_HASH_INC_APPLY_COUNT(Z_ARRVAL_P(value_noref));
 					}
 					msgpack_serialize_zval(buf, value, var_hash);
-					if (Z_TYPE_P(value_noref) == IS_ARRAY) {
+					if (Z_TYPE_P(value_noref) == IS_ARRAY && ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(value_noref))) {
 						ZEND_HASH_DEC_APPLY_COUNT(Z_ARRVAL_P(value_noref));
 					}
 				}
@@ -310,13 +310,13 @@ static inline void msgpack_serialize_array(smart_str *buf, zval *val, HashTable 
 						data_noref = data;
 					}
 
-					if (Z_TYPE_P(data_noref) == IS_ARRAY) {
+					if (Z_TYPE_P(data_noref) == IS_ARRAY && ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(data_noref))) {
 						ZEND_HASH_INC_APPLY_COUNT(Z_ARRVAL_P(data_noref));
 					}
 
 					msgpack_serialize_zval(buf, data, var_hash);
 
-					if (Z_TYPE_P(data_noref) == IS_ARRAY) {
+					if (Z_TYPE_P(data_noref) == IS_ARRAY && ZEND_HASH_APPLY_PROTECTION(Z_ARRVAL_P(data_noref))) {
 						ZEND_HASH_DEC_APPLY_COUNT(Z_ARRVAL_P(data_noref));
 					}
 				}

--- a/tests/029.phpt
+++ b/tests/029.phpt
@@ -48,7 +48,7 @@ extension Version => %s
 header Version => %s
 
 Directive => Local Value => Master Value
-msgpack.error_display => On => On
-msgpack.illegal_key_insert => Off => Off
-msgpack.php_only => On => On
-msgpack.use_str8_serialization => On => On
+msgpack.error_display => %s => %s
+msgpack.illegal_key_insert => %s => %s
+msgpack.php_only => %s => %s
+msgpack.use_str8_serialization => %s => %s

--- a/tests/137.phpt
+++ b/tests/137.phpt
@@ -1,5 +1,7 @@
 --TEST--
 unpack/pack str8
+--INI--
+msgpack.use_str8_serialization = 1
 --SKIPIF--
 <?php
 	if (version_compare(PHP_VERSION, '5.2.0') < 0) {


### PR DESCRIPTION
This might also address the xfail on the bug002 test, although I am now getting a parse error on the unserialize on that test.