### PR TITLE
match type of var_entries.used_slots

### DIFF
--- a/msgpack_unpack.c
+++ b/msgpack_unpack.c
@@ -11,7 +11,7 @@
 
 typedef struct {
     zval data[VAR_ENTRIES_MAX];
-    int32_t used_slots;
+    zend_long used_slots;
     void *next;
 } var_entries;
 
@@ -98,7 +98,7 @@ static inline void msgpack_var_replace(zval *old, zval *new) /* {{{ */ {
 }
 /* }}} */
 
-static zval *msgpack_var_access(msgpack_unserialize_data_t *var_hashx, long id) /* {{{ */ {
+static zval *msgpack_var_access(msgpack_unserialize_data_t *var_hashx, zend_long id) /* {{{ */ {
     var_entries *var_hash = var_hashx->first;
 
     while (id >= VAR_ENTRIES_MAX && var_hash && var_hash->used_slots == VAR_ENTRIES_MAX) {
@@ -280,7 +280,7 @@ void msgpack_unserialize_var_init(msgpack_unserialize_data_t *var_hashx) /* {{{ 
 /* }}} */
 
 void msgpack_unserialize_var_destroy(msgpack_unserialize_data_t *var_hashx, zend_bool err) /* {{{ */ {
-	size_t i;
+	zend_long i;
     void *next;
     var_entries *var_hash = var_hashx->first;
 


### PR DESCRIPTION
we were encountering segfaults due to the types of `used_slots` and iteration variable `i` not matching (signed int vs `size_t` which is unsigned).

making the types match solves the problem.
I changed them both to `zend_long` as that's what PHP uses for the identical struct used in `var_unserializer.c`.
Obviously I can revert this and simply change `i` to be an `int32_t` if that's preferred.

Segfault we were seeing:

```
#0  0x000055555579d2e9 in _zval_ptr_dtor ()
#1  0x00007fffeaeb7180 in msgpack_unserialize_var_destroy (var_hashx=var_hashx@entry=0x7fffffff01c0, err=err@entry=0 '\000') at /home/m.heijkoop/repos/msgpack-php/msgpack_unpack.c:301
#2  0x00007fffeaeb1633 in php_msgpack_unserialize (return_value=return_value@entry=0x7ffff5e130e0, str=0x7fffe5f88018 "\207\263\063\060-prijsplan-674-24\204\300\001\331&T-Mobile-Madness-0-Minuten-0-MB-2-jaar\207\300\001", str_len=76204) at /home/m.heijkoop/repos/msgpack-php/msgpack.c:238
#3  0x00007fffeaeb1808 in zif_msgpack_unserialize (execute_data=<optimized out>, return_value=0x7ffff5e130e0) at /home/m.heijkoop/repos/msgpack-php/msgpack.c:285
#4  0x000055555579d13b in dtrace_execute_internal ()
#5  0x00007ffff51c5381 in xdebug_execute_internal (current_execute_data=0x7ffff5e13100, return_value=0x7ffff5e130e0) at /build/xdebug-CUWooE/xdebug-2.4.1/build-7.0/xdebug.c:2048
#6  0x00005555558268f4 in ?? ()
#7  0x00005555557e8bab in execute_ex ()
#8  0x000055555579d039 in dtrace_execute_ex ()
#9  0x00007ffff51c4a0f in xdebug_execute_ex (execute_data=0x7ffff5e13030) at /build/xdebug-CUWooE/xdebug-2.4.1/build-7.0/xdebug.c:1900
#10 0x000055555583241f in zend_execute ()
#11 0x00005555557ac5e4 in zend_execute_scripts ()
#12 0x000055555574fed8 in php_execute_script ()
#13 0x0000555555833ff9 in ?? ()
#14 0x000055555563d8e0 in main ()
```

(Note the build for this pull fails due to master currently failing, which is fixed by #109 )