### PR TITLE
Fix for crash with references on PHP7

### DIFF
--- a/msgpack_unpack.c
+++ b/msgpack_unpack.c
@@ -92,7 +92,7 @@ static zval *msgpack_var_push(msgpack_unserialize_data_t *var_hashx) /* {{{ */ {
 /* }}} */
 
 static inline void msgpack_var_replace(zval *old, zval *new) /* {{{ */ {
-	if (!MSGPACK_IS_STACK_VALUE(old)) {
+	if (!MSGPACK_IS_STACK_VALUE(old) && Z_TYPE_P(old) != IS_REFERENCE) {
 		ZVAL_INDIRECT(old, new);
 	}
 }

--- a/tests/issue094.phpt
+++ b/tests/issue094.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Issue #94 (PHP7 segmentation fault with references)
+--SKIPIF--
+<?php
+if (!extension_loaded("msgpack")) {
+   echo "skip"; 
+}
+--FILE--
+<?php
+$bad = unserialize('a:4:{i:1;a:1:{s:10:"verylongid";s:1:"1";}i:10;a:1:{s:10:"verylongid";s:2:"10";}i:16;a:1:{s:10:"verylongid";s:2:"16";}i:0;a:1:{s:8:"children";a:3:{i:16;R:6;i:10;R:4;i:1;R:2;}}}');
+$p = msgpack_pack($bad);
+print_r(msgpack_unpack($p));
+--EXPECT--
+Array
+(
+    [1] => Array
+        (
+            [verylongid] => 1
+        )
+
+    [10] => Array
+        (
+            [verylongid] => 10
+        )
+
+    [16] => Array
+        (
+            [verylongid] => 16
+        )
+
+    [0] => Array
+        (
+            [children] => Array
+                (
+                    [16] => Array
+                        (
+                            [verylongid] => 16
+                        )
+
+                    [10] => Array
+                        (
+                            [verylongid] => 10
+                        )
+
+                    [1] => Array
+                        (
+                            [verylongid] => 1
+                        )
+
+                )
+
+        )
+
+)


### PR DESCRIPTION
This solves #94.

I've turned the example in the issue into a test for the issue and added a workaround which passes the test.

It's likely there's a better solution for this, but we were seeing this problem in production so making the symptoms go away needed to be done urgently.

I would expect this change to introduce a memory leak, but after running for a couple of days on our high-traffic php-fpm backend I'm not seeing much of that. Obviously ymmv.

I've managed to trace the issue to the zval of `$bad[1]` getting corrupted after `$bad[10]` is parsed. `$bad[1]` turns into an `IS_INDIRECT` pointing to an `IS_REFERENCE`, pointing to an array. The second element array (`$bad[10]`) does **not** turn into an indirect and is merely a reference to an array.

This corruption doesn't occur when I exempt `IS_INDIRECT` zvals in `msgpack_var_replace`.

I'm hoping this either suffices as a fix or points someone with more experience with these internals to the 'proper' solution.

(Note the build for this pull fails due to master currently failing 041.phpt, which is fixed by #109 )