### PR TITLE
fix ce->name is a zend_string

### DIFF
--- a/msgpack_convert.c
+++ b/msgpack_convert.c
@@ -314,7 +314,7 @@ int msgpack_convert_object(zval *return_value, zval *tpl, zval *value) /* {{{ */
         if (zend_call_function(&fci, &fcc) == FAILURE) {
             MSGPACK_WARNING(
                 "[msgpack] (%s) Invocation of %s's constructor failed",
-                __FUNCTION__, ce->name);
+                __FUNCTION__, ZSTR_VAL(ce->name));
 
             return FAILURE;
         }

--- a/msgpack_unpack.c
+++ b/msgpack_unpack.c
@@ -557,7 +557,7 @@ int msgpack_unserialize_map_item(msgpack_unserialize_data *unpack, zval **contai
                     if (ce->unserialize == NULL) {
                         MSGPACK_WARNING(
                             "[msgpack] (%s) Class %s has no unserializer",
-                            __FUNCTION__, ce->name);
+                            __FUNCTION__, ZSTR_VAL(ce->name));
 
                         MSGPACK_UNSERIALIZE_FINISH_MAP_ITEM(unpack, key, val);
 


### PR DESCRIPTION
1st part is for 7.3 (fcc.initialized removed)

2nd is for 7.0+ (7.3 allow to raise to -Wformat warning and thus detect this issue)