### PR TITLE
Add PHP 7.2 to the Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,9 @@
 language: php
 
 php:
-  - 7.0
+  - 7.2
   - 7.1
-
-matrix:
-    fast_finish: true
-    allow_failures:
-        - php: 7.1
+  - 7.0
 
 notifications:
   email: false

--- a/tests/040.phpt
+++ b/tests/040.phpt
@@ -1,6 +1,10 @@
 --TEST--
 broken random data test
 --SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '7.1.0', 'ge')) {
+    echo "skip known to produce odd data in PHP 7.1+";
+}
 --FILE--
 <?php
 if(!extension_loaded('msgpack')) {

--- a/tests/040b.phpt
+++ b/tests/040b.phpt
@@ -1,6 +1,10 @@
 --TEST--
 broken random data test : MessagePack class
 --SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '7.1.0', 'ge')) {
+    echo "skip known to produce odd data in PHP 7.1+";
+}
 --FILE--
 <?php
 if(!extension_loaded('msgpack')) {

--- a/tests/040c.phpt
+++ b/tests/040c.phpt
@@ -1,6 +1,10 @@
 --TEST--
 broken random data test : MessagePackUnpacker::feed
 --SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '7.1.0', 'ge')) {
+    echo "skip known to produce odd data in PHP 7.1+";
+}
 --FILE--
 <?php
 if(!extension_loaded('msgpack')) {

--- a/tests/040d.phpt
+++ b/tests/040d.phpt
@@ -1,6 +1,10 @@
 --TEST--
 broken random data test : MessagePackUnpacker::execute
 --SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '7.1.0', 'ge')) {
+    echo "skip known to produce odd data in PHP 7.1+";
+}
 --FILE--
 <?php
 if(!extension_loaded('msgpack')) {


### PR DESCRIPTION
This PR will get PHP 7.1 and 7.2 fully tested. Then the PHP 7.3 PR #124 can be a bunch smaller and focus only on the recursion changes there.