### PR TITLE
fix build with php 8

### DIFF
--- a/msgpack_class.c
+++ b/msgpack_class.c
@@ -274,7 +274,7 @@ static ZEND_METHOD(msgpack, unpacker) /* {{{ */ {
     ZVAL_STRING(&func_name, "__construct");
 
     object_init_ex(return_value, msgpack_unpacker_ce);
-    call_user_function_ex(CG(function_table), return_value, &func_name, &construct_return, 1, args, 0, NULL);
+    call_user_function(CG(function_table), return_value, &func_name, &construct_return, 1, args);
 
     zval_ptr_dtor(&func_name);
 }

--- a/msgpack_convert.c
+++ b/msgpack_convert.c
@@ -36,7 +36,7 @@ static inline int msgpack_convert_long_to_properties(HashTable *ht, zval *object
 
                                 if (msgpack_convert_array(&tplval, data, dataval) == SUCCESS) {
                                     zend_hash_move_forward_ex(props, prop_pos);
-                                    zend_update_property(Z_OBJCE_P(object), object, prop_name, prop_len, &tplval);
+                                    zend_update_property(Z_OBJCE_P(object), OBJ_FOR_PROP(object), prop_name, prop_len, &tplval);
                                     return SUCCESS;
                                 }
                                 return FAILURE;
@@ -45,14 +45,14 @@ static inline int msgpack_convert_long_to_properties(HashTable *ht, zval *object
                             {
                                 if (msgpack_convert_object(&tplval, data, val) == SUCCESS) {
                                     zend_hash_move_forward_ex(props, prop_pos);
-                                    zend_update_property(Z_OBJCE_P(object), object, prop_name, prop_len, &tplval);
+                                    zend_update_property(Z_OBJCE_P(object), OBJ_FOR_PROP(object), prop_name, prop_len, &tplval);
                                     return SUCCESS;
                                 }
                                 return FAILURE;
                             }
                             default:
                                 zend_hash_move_forward_ex(props, prop_pos);
-                                zend_update_property(Z_OBJCE_P(object), object, prop_name, prop_len, val);
+                                zend_update_property(Z_OBJCE_P(object), OBJ_FOR_PROP(object), prop_name, prop_len, val);
                             return SUCCESS;
                         }
                     }
@@ -89,10 +89,10 @@ static inline int msgpack_convert_string_to_properties(zval *object, zend_string
     prot_name = zend_mangle_property_name("*", 1, ZSTR_VAL(key), ZSTR_LEN(key), 1);
 
     if (zend_hash_find(propers, priv_name) != NULL) {
-        zend_update_property_ex(ce, object, key, val);
+        zend_update_property_ex(ce, OBJ_FOR_PROP(object), key, val);
         return_code = SUCCESS;
     } else if (zend_hash_find(propers, prot_name) != NULL) {
-        zend_update_property_ex(ce, object, key, val);
+        zend_update_property_ex(ce, OBJ_FOR_PROP(object), key, val);
         return_code = SUCCESS;
     } else {
 #if PHP_VERSION_ID < 80000
@@ -310,8 +310,9 @@ int msgpack_convert_object(zval *return_value, zval *tpl, zval *value) /* {{{ */
         fci.retval = &retval;
         fci.param_count = 0;
         fci.params = &params;
+#if PHP_VERSION_ID < 80000
         fci.no_separation = 1;
-
+#endif
 #if PHP_VERSION_ID < 70300
         fcc.initialized = 1;
 #endif
@@ -434,10 +435,10 @@ int msgpack_convert_object(zval *return_value, zval *tpl, zval *value) /* {{{ */
                             return FAILURE;
                         }
 
-                        zend_update_property_ex(ce, return_value, str_key, &nv);
+                        zend_update_property_ex(ce, OBJ_FOR_PROP(return_value), str_key, &nv);
                         zval_ptr_dtor(&nv);
                     } else  {
-                        zend_update_property(ce, return_value, prop_name, prop_len, aryval);
+                        zend_update_property(ce, OBJ_FOR_PROP(return_value), prop_name, prop_len, aryval);
                     }
                     num_key++;
                 } ZEND_HASH_FOREACH_END();

--- a/msgpack_pack.c
+++ b/msgpack_pack.c
@@ -223,7 +223,7 @@ static inline void msgpack_serialize_array(smart_str *buf, zval *val, HashTable 
     if (object) {
 #if PHP_VERSION_ID >= 70400
         if (Z_OBJ_HANDLER_P(val, get_properties_for)) {
-            ht = Z_OBJ_HANDLER_P(val, get_properties_for)(val, ZEND_PROP_PURPOSE_ARRAY_CAST);
+            ht = Z_OBJ_HANDLER_P(val, get_properties_for)(OBJ_FOR_PROP(val), ZEND_PROP_PURPOSE_ARRAY_CAST);
             free_ht = 1;
         } else {
             ht = Z_OBJPROP_P(val);
@@ -409,7 +409,7 @@ static inline void msgpack_serialize_object(smart_str *buf, zval *val, HashTable
 
     if (ce && ce != PHP_IC_ENTRY &&
             zend_hash_exists(&ce->function_table, sleep_zstring)) {
-        if ((res = call_user_function_ex(CG(function_table), val_noref, &fname, &retval, 0, 0, 1, NULL)) == SUCCESS) {
+        if ((res = call_user_function(CG(function_table), val_noref, &fname, &retval, 0, 0)) == SUCCESS) {
 
             if (EG(exception)) {
                 zval_ptr_dtor(&retval);

--- a/msgpack_unpack.c
+++ b/msgpack_unpack.c
@@ -282,7 +282,7 @@ static zend_class_entry* msgpack_unserialize_class(zval **container, zend_string
         ZVAL_STRING(&user_func, PG(unserialize_callback_func));
         ZVAL_STR(&args[0], class_name);
 
-        func_call_status = call_user_function_ex(CG(function_table), NULL, &user_func, &retval, 1, args, 0, NULL);
+        func_call_status = call_user_function(CG(function_table), NULL, &user_func, &retval, 1, args);
         zval_ptr_dtor(&user_func);
         if (func_call_status != SUCCESS) {
             MSGPACK_WARNING("[msgpack] (%s) defined (%s) but not found",
@@ -329,7 +329,11 @@ static zend_class_entry* msgpack_unserialize_class(zval **container, zend_string
 
     /* store incomplete class name */
     if (incomplete_class) {
+#if PHP_VERSION_ID < 80000
         php_store_class_name(container_val, ZSTR_VAL(class_name), ZSTR_LEN(class_name));
+#else
+        php_store_class_name(container_val, class_name);
+#endif
     }
 
     return ce;
@@ -836,7 +840,7 @@ int msgpack_unserialize_map_item(msgpack_unserialize_data *unpack, zval **contai
                 zend_hash_str_exists(&Z_OBJCE_P(container_val)->function_table, "__wakeup", sizeof("__wakeup") - 1)) {
             zval wakeup, r;
             ZVAL_STRING(&wakeup, "__wakeup");
-            call_user_function_ex(CG(function_table), container_val, &wakeup, &r, 0, NULL, 1, NULL);
+            call_user_function(CG(function_table), container_val, &wakeup, &r, 0, NULL);
             zval_ptr_dtor(&r);
             zval_ptr_dtor(&wakeup);
         }

--- a/php_msgpack.h
+++ b/php_msgpack.h
@@ -52,4 +52,10 @@ PHP_MSGPACK_API int php_msgpack_unserialize(
 # define MSGPACK_ENDIAN_BIG_BYTE 0
 #endif
 
+#if PHP_VERSION_ID < 80000
+# define OBJ_FOR_PROP(zv) (zv)
+#else
+# define OBJ_FOR_PROP(zv) Z_OBJ_P(zv)
+#endif
+
 #endif  /* PHP_MSGPACK_H */


### PR DESCRIPTION
Obviously not enough, just for start

Some still failing

```
TEST 9/132 [tests/009.phpt]
========DIFF========
048+     *RECURSION*
048-     &array(1) {
049-       [0]=>
050-       *RECURSION*
051-     }
========DONE========
FAIL Check for reference serialization [tests/009.phpt] 

TEST 27/132 [tests/026.phpt]
========DIFF========
033+     *RECURSION*
033-     array(1) {
034-       ["foo"]=>
035-       *RECURSION*
036-     }
========DONE========
FAIL Cyclic array test [tests/026.phpt] 

TEST 131/132 [tests/issue137.phpt]
========DIFF========
001+ Termsig=11
001- object(DateTimeImmutable)#%d (3) {
002-   ["date"]=>
003-   string(26) "%d-%d-%d %d:%d:%f"
004-   ["timezone_type"]=>
005-   int(%d)
006-   ["timezone"]=>
007-   string(%d) "%s"
008- }
009- OK
========DONE========
FAIL Issue #137 (DateTime(Immutable) serialization doesn't work with php 7.4) [tests/issue137.phpt] 

```

Last being the more annoying....