### PR TITLE
proper implementation for __(un)serializ magic methods

### DIFF
--- a/tests/021.phpt
+++ b/tests/021.phpt
@@ -40,11 +40,11 @@ class Obj implements Serializable {
     }
 
     public function __serialize() {
-        return $this->serialize();
+        return [$this->serialize()];
     }
 
     public function __unserialize($serialized) {
-        return $this->unserialize();
+        return $this->unserialize($serialized[0]);
     }
 }
 

--- a/tests/031.phpt
+++ b/tests/031.phpt
@@ -48,11 +48,11 @@ class Obj implements Serializable {
     }
 
     public function __serialize() {
-        return $this->serialize();
+        return [$this->serialize()];
     }
 
     public function __unserialize($serialized) {
-        return $this->unserialize();
+        return $this->unserialize($serialized[0]);
     }
 }
 

--- a/tests/042.phpt
+++ b/tests/042.phpt
@@ -25,11 +25,11 @@ class Foo implements Serializable {
     }
 
     public function __serialize() {
-        return $this->serialize();
+        return [$this->serialize()];
     }
 
     public function __unserialize($serialized) {
-        return $this->unserialize();
+        return $this->unserialize($serialized[0]);
     }
 }
 


### PR DESCRIPTION
Sorry, but fff660a6f85b69e5dfe090f767cad13531d4ce3e use bad implementation
Fixed accroding to https://wiki.php.net/rfc/custom_object_serialization

(btw, test suite was OK... so methods not really used)