### PR TITLE
Add serialization and deserialization support for PHP 8.1 Enums.

### DIFF
--- a/msgpack_pack.c
+++ b/msgpack_pack.c
@@ -6,6 +6,10 @@
 #include "ext/standard/php_incomplete_class.h"
 #include "ext/standard/php_var.h"
 
+#if PHP_VERSION_ID >= 80100
+#include "Zend/zend_enum.h"
+#endif
+
 #include "php_msgpack.h"
 #include "msgpack_pack.h"
 #include "msgpack_errors.h"
@@ -405,6 +409,19 @@ static inline void msgpack_serialize_object(smart_str *buf, zval *val, HashTable
     if (ce && (ce->ce_flags & ZEND_ACC_NOT_SERIALIZABLE)) {
         msgpack_pack_nil(buf);
         zend_throw_exception_ex(NULL, 0, "Serialization of '%s' is not allowed", ZSTR_VAL(ce->name));
+        PHP_CLEANUP_CLASS_ATTRIBUTES();
+        return;
+    }
+    if (ce && (ce->ce_flags & ZEND_ACC_ENUM)) {
+        zval *enum_case_name = zend_enum_fetch_case_name(Z_OBJ_P(val_noref));
+        msgpack_pack_map(buf, 2);
+
+        msgpack_pack_nil(buf);
+        msgpack_pack_long(buf, MSGPACK_SERIALIZE_TYPE_ENUM);
+
+        msgpack_serialize_string(buf, ZSTR_VAL(ce->name), ZSTR_LEN(ce->name));
+        msgpack_serialize_string(buf, Z_STRVAL_P(enum_case_name), Z_STRLEN_P(enum_case_name));
+
         PHP_CLEANUP_CLASS_ATTRIBUTES();
         return;
     }

--- a/msgpack_pack.h
+++ b/msgpack_pack.h
@@ -19,6 +19,7 @@ enum msgpack_serialize_type
     MSGPACK_SERIALIZE_TYPE_CUSTOM_OBJECT,
     MSGPACK_SERIALIZE_TYPE_OBJECT,
     MSGPACK_SERIALIZE_TYPE_OBJECT_REFERENCE,
+    MSGPACK_SERIALIZE_TYPE_ENUM,
 };
 
 void msgpack_serialize_var_init(msgpack_serialize_data_t *var_hash);

--- a/tests/issue171.phpt
+++ b/tests/issue171.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Issue #171 (Serializing & Unserializing Enum)
+--SKIPIF--
+<?php
+if (!extension_loaded("msgpack")) {
+    exit('skip because msgpack extension is missing');
+}
+if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+    exit('skip Enum tests in PHP older than 8.1.0');
+}
+?>
+--FILE--
+Test
+<?php
+enum TestEnum {
+    case EITHER;
+    case OTHER;
+}
+
+$packed = msgpack_pack(TestEnum::OTHER);
+var_dump(bin2hex($packed));
+
+$unpacked = msgpack_unpack($packed);
+var_dump($unpacked);
+?>
+OK
+--EXPECT--
+Test
+string(36) "82c006a854657374456e756da54f54484552"
+enum(TestEnum::OTHER)
+OK


### PR DESCRIPTION
Add support for enum classes. They are serialized with a new serialize type `MSGPACK_SERIALIZE_TYPE_ENUM` (dynamic id 6) and stored by using the enum class name as key and the enum case name as value.

For example the serialized message pack blob from the added test (generated by `msgpack-inspect`):
```yaml
---
- format: "fixmap"
  header: "0x82"
  length: 2
  children:
    - key:
        format: "nil"
        header: "0xc0"
        data: "0xc0"
        value: null
      value:
        format: "fixint"
        header: "0x06"
        data: "0x06"
        value: 6
    - key:
        format: "fixstr"
        header: "0xa8"
        length: 8
        data: "0x54657374456e756d"
        value: "TestEnum"
      value:
        format: "fixstr"
        header: "0xa5"
        length: 5
        data: "0x4f54484552"
        value: "OTHER"
```

Fixes issue #171.

This is incompatible with enums serialized before this change as they have been serialized as normal classes and thus did not set a numeric serialize type but the class name instead. Thus, old data will continue to fail deserialization in the same way if it does contain a serialized enum.