### PR TITLE
Allow forcing floats to be encoded as F32

### DIFF
--- a/msgpack.c
+++ b/msgpack.c
@@ -55,6 +55,9 @@ STD_PHP_INI_BOOLEAN(
 STD_PHP_INI_BOOLEAN(
     "msgpack.use_str8_serialization", "1", PHP_INI_ALL, OnUpdateBool,
     use_str8_serialization, zend_msgpack_globals, msgpack_globals)
+STD_PHP_INI_BOOLEAN(
+    "msgpack.force_f32", "0", PHP_INI_ALL, OnUpdateBool,
+    force_f32, zend_msgpack_globals, msgpack_globals)
 PHP_INI_END()
 
 #if HAVE_PHP_SESSION
@@ -115,6 +118,8 @@ static ZEND_MINIT_FUNCTION(msgpack) /* {{{ */ {
             MSGPACK_CLASS_OPT_PHPONLY, CONST_CS | CONST_PERSISTENT);
     REGISTER_LONG_CONSTANT("MESSAGEPACK_OPT_ASSOC",
             MSGPACK_CLASS_OPT_ASSOC, CONST_CS | CONST_PERSISTENT);
+    REGISTER_LONG_CONSTANT("MESSAGEPACK_OPT_FORCE_F32",
+            MSGPACK_CLASS_OPT_FORCE_F32, CONST_CS | CONST_PERSISTENT);
 
     return SUCCESS;
 }

--- a/msgpack_class.h
+++ b/msgpack_class.h
@@ -4,6 +4,7 @@
 
 #define MSGPACK_CLASS_OPT_PHPONLY -1001
 #define MSGPACK_CLASS_OPT_ASSOC -1002
+#define MSGPACK_CLASS_OPT_FORCE_F32 -1003
 
 void msgpack_init_class();
 

--- a/msgpack_pack.c
+++ b/msgpack_pack.c
@@ -589,7 +589,11 @@ void msgpack_serialize_zval(smart_str *buf, zval *val, HashTable *var_hash) /* {
             msgpack_pack_long(buf, zval_get_long(val_noref));
             break;
         case IS_DOUBLE:
-            msgpack_pack_double(buf, Z_DVAL_P(val_noref));
+            if (MSGPACK_G(force_f32)) {
+                msgpack_pack_float(buf, (float) Z_DVAL_P(val_noref));
+            } else {
+                msgpack_pack_double(buf, Z_DVAL_P(val_noref));
+            }
             break;
         case IS_STRING:
             msgpack_serialize_string(buf, Z_STRVAL_P(val_noref), Z_STRLEN_P(val_noref));

--- a/php_msgpack.h
+++ b/php_msgpack.h
@@ -26,6 +26,7 @@ ZEND_BEGIN_MODULE_GLOBALS(msgpack)
     zend_bool assoc;
     zend_bool illegal_key_insert;
     zend_bool use_str8_serialization;
+	zend_bool force_f32;
     struct {
         void *var_hash;
         unsigned level;

--- a/tests/029.phpt
+++ b/tests/029.phpt
@@ -51,6 +51,7 @@ header Version => %s
 Directive => Local Value => Master Value
 msgpack.assoc => %s => %s
 msgpack.error_display => %s => %s
+msgpack.force_f32 => Off => Off
 msgpack.illegal_key_insert => %s => %s
 msgpack.php_only => %s => %s
 msgpack.use_str8_serialization => %s => %s

--- a/tests/141.phpt
+++ b/tests/141.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Check for f32 serialisation
+--SKIPIF--
+--FILE--
+<?php
+if(!extension_loaded('msgpack')) {
+    dl('msgpack.' . PHP_SHLIB_SUFFIX);
+}
+
+function test($type, $variable) {
+    $packer = new \MessagePack(false);
+
+    $packer->setOption(\MessagePack::OPT_FORCE_F32, true);
+
+    $serialized = $packer->pack($variable);
+
+    echo $type, PHP_EOL;
+    echo bin2hex($serialized), PHP_EOL;
+}
+
+test('double: 123.456', 123.456);
+?>
+--EXPECT--
+double: 123.456
+ca42f6e979

--- a/tests/142.phpt
+++ b/tests/142.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Check for f32 serialisation
+--SKIPIF--
+--INI--
+msgpack.force_f32 = 1
+--FILE--
+<?php
+if(!extension_loaded('msgpack')) {
+    dl('msgpack.' . PHP_SHLIB_SUFFIX);
+}
+
+function test($type, $variable) {
+    $serialized = msgpack_pack($variable);
+
+    echo $type, PHP_EOL;
+    echo bin2hex($serialized), PHP_EOL;
+}
+
+test('double: 123.456', 123.456);
+?>
+--EXPECT--
+double: 123.456
+ca42f6e979

--- a/tests/143.phpt
+++ b/tests/143.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Check for f32 serialisation
+--SKIPIF--
+--INI--
+msgpack.force_f32 = 1
+--FILE--
+<?php
+if(!extension_loaded('msgpack')) {
+    dl('msgpack.' . PHP_SHLIB_SUFFIX);
+}
+
+function test($type, $variable) {
+    $packer = new \MessagePack(false);
+
+    $serialized = $packer->pack($variable);
+
+    echo $type, PHP_EOL;
+    echo bin2hex($serialized), PHP_EOL;
+}
+
+test('double: 123.456', 123.456);
+?>
+--EXPECT--
+double: 123.456
+ca42f6e979


### PR DESCRIPTION
This merge allows users to force floats to be encoded as 32-bit floats (float 32) rather than the default 64-bit doubles. This would primarily be useful for reducing the storage size of the packed result, and has no effect on unpacking, aside from the loss in precision that will happen transparently.

If there is appetite for this and this fits with style/structure expected I will expand to allow similarly forcing int8,int16 etc.

I've implemented this as an option on the packer class, but also as an ini flag (though I'm unsure if that's actually useful).