### PR TITLE
fix build with PHP 8.6: unserialize_callback_func is a zend_string

### DIFF
--- a/msgpack_unpack.c
+++ b/msgpack_unpack.c
@@ -276,15 +276,25 @@ static zend_class_entry* msgpack_unserialize_class(zval **container, zend_string
         }
 
         /* Check for unserialize callback */
+#if PHP_VERSION_ID >= 80600
+        /* php 8.6 turned the unserialize_callback_func global into a zend_string* */
+        if ((PG(unserialize_callback_func) == NULL) ||
+            (ZSTR_LEN(PG(unserialize_callback_func)) == 0)) {
+#else
         if ((PG(unserialize_callback_func) == NULL) ||
             (PG(unserialize_callback_func)[0] == '\0')) {
+#endif
             incomplete_class = 1;
             ce = PHP_IC_ENTRY;
             break;
         }
 
         /* Call unserialize callback */
+#if PHP_VERSION_ID >= 80600
+        ZVAL_STR(&user_func, zend_string_dup(PG(unserialize_callback_func), false));
+#else
         ZVAL_STRING(&user_func, PG(unserialize_callback_func));
+#endif
         ZVAL_STR(&args[0], class_name);
 
         func_call_status = call_user_function(CG(function_table), NULL, &user_func, &retval, 1, args);


### PR DESCRIPTION
php-src commit https://github.com/php/php-src/commit/c82acefe470 converted the `PG(unserialize_callback_func)` global from `char*` to `zend_string*`, so `msgpack_unserialize_class()` no longer compiles against PHP 8.6.

Mirror what ext/standard/var_unserializer.re does in 8.6: an empty ini value is a non-NULL zero-length string and must still be treated as no callback, and the name is duplicated rather than refcounted since the ini string may be persistent.